### PR TITLE
Migrating plugin to be hosted at GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Changelog
 
+#### 3.0.0
+* Released: 2020-07-03
+* Plugin is now hosted on [GitHub](https://github.com/HeyPublisher/amazon-book-store)
+* Fixed issue with call to function `split` not being found in PHP versions 7.0 and above.
+* Added an updater that will check GitHub for latest version and update locally.
+* Organized code around HeyPublisher/Base class
+* Validated plugin works up through WordPress 5.3
+
 #### 2.2.1
 * Released: 2017-05-27
 * Fixed an issue where affiliate code would not stick if changing from any international affiliate country back to US.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 
 #### 1.0.1
 * Updated screenshots to highlight the fact that users should change their Amazon Associate ID.
-* Plugin is now owned and maintained by [Loudlever, Inc.](http://www.loudlever.com)
+* Plugin is now owned and maintained by [Loudlever, Inc.](https://www.loudlever.com)
 * Update Release (03/26/2010)
 
 #### 1.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requires at least: 4.0
 Tested up to: 4.7.3
 Stable tag: 2.2.1
 License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 ```
 
 Sell Amazon products in sidebar widgets, unique to the individual POST or generically from a default pool of products that you define.
@@ -31,7 +31,7 @@ Install the plugin, then activate it.  Once activated, configure the Widget:
 
 **Configure the ASIN pool**
 
-Navigate to 'Settings' -> 'Amazon Book Store'.  Input your Amazon Affiliate ID and country, the add the ASINs for the products you want to be displayed in the widget.  See [How to Find Amazon ASINs](http://askville.amazon.com/find-Amazon-ASIN-product-details-page/AnswerViewer.do?requestId=11106037) for more information.  There are two categorizations of settings:
+Navigate to 'Settings' -> 'Amazon Book Store'.  Input your Amazon Affiliate ID and country, the add the ASINs for the products you want to be displayed in the widget.  See [How to Find Amazon ASINs](https://www.amazon.com/gp/seller/asin-upc-isbn-info.html) for more information.  There are two categorizations of settings:
 
 * POST Specific:  When set, these products will be offered for sale when users read the associated POST.
 * Default: If the request is to a POST that does not have specific ASINs defined, the widget will display products from this group.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,5 @@
 ## Amazon Book Store
 
-```
-Contributors: heypublisher, aguywithanidea, loudlever
-Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=Y8SL68GN5J2PL
-Tags: affiliate, amazon, product, book store, affiliate sales,ASIN, Amazon Associate, monetize, heypublisher
-Requires at least: 4.0
-Tested up to: 4.7.3
-Stable tag: 2.2.1
-License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
-```
-
 Sell Amazon products in sidebar widgets, unique to the individual POST or generically from a default pool of products that you define.
 
 ### Description

--- a/include/classes/AMZNBS/Admin.class.php
+++ b/include/classes/AMZNBS/Admin.class.php
@@ -1,5 +1,6 @@
 <?php
 namespace AMZNBS;
+
 /*
   Admin Class
 
@@ -24,21 +25,22 @@ class Admin extends \HeyPublisher\Base {
   public function __construct() {
     parent::__construct();
     $this->options = get_option(SGW_PLUGIN_OPTTIONS);
-    $this->log(sprintf("in constructor\nopts = %s",print_r($this->options,true)));
+    $this->logger->debug(sprintf("in constructor\nopts = %s",print_r($this->options,true)));
     // $this->check_plugin_version();  // may need to reintroduce this
     $this->nav_slug = SGW_ADMIN_PAGE; // not 'amazon_bookstore' because this needs to map to dir name
     $this->slug = 'support-great-writers'; // not 'amazon_bookstore' because this needs to map to dir name
     // Sidebar configs
-    $this->plugin['home'] = 'https://wordpress.org/plugins/support-great-writers/';
-    $this->plugin['support'] = 'https://wordpress.org/support/plugin/support-great-writers';
+    $this->plugin['home'] = 'https://github.com/HeyPublisher/amazon-book-store';
+    $this->plugin['support'] = 'https://github.com/HeyPublisher/amazon-book-store/issues';
     $this->plugin['contact'] = 'mailto:wordpress@heypublisher.com';
+    $this->plugin['more'] = 'https://github.com/HeyPublisher/';
   }
 
   public function __destruct() {
     parent::__destruct();
   }
   public function activate_plugin() {
-    $this->log("in the activate_plugin()");
+    $this->logger->debug("in the activate_plugin()");
     $this->check_plugin_version();
   }
 
@@ -71,12 +73,12 @@ class Admin extends \HeyPublisher\Base {
   }
 
     public function check_plugin_version() {
-    $this->log("in check_plugin_version()");
+    $this->logger->debug("in check_plugin_version()");
 
     $opts = get_option(SGW_PLUGIN_OPTTIONS);
     // printf("<pre>In check_plugin_version()\n opts = %s</pre>",print_r($opts,1));
     if (!$opts || !$opts[plugin] || $opts[plugin][version_last] == false) {
-      $this->log("no old version - initializing");
+      $this->logger->debug("no old version - initializing");
       $this->init_plugin();
       // there is a possible upgrade path from old widget to this one - in which case we want to migrate data
       $this->migrate_old_widget();
@@ -84,7 +86,7 @@ class Admin extends \HeyPublisher\Base {
     }
     // check for upgrade option here
     if ($opts[plugin][version_current] != SGW_PLUGIN_VERSION) {
-      $this->log("need to upgrade version");
+      $this->logger->debug("need to upgrade version");
       $this->upgrade_plugin($opts);
       return;
     }
@@ -182,7 +184,7 @@ class Admin extends \HeyPublisher\Base {
       // $this->error = 'You must input at least one ASIN'; return false;
     }
     $new = array();
-    $array = split(',',$list);
+    $array = explode(',',$list);
     foreach ($array as $asin) {
       $x = trim($asin);
       if (strlen($x) != 10) {

--- a/include/classes/HeyPublisher/Base.class.php
+++ b/include/classes/HeyPublisher/Base.class.php
@@ -1,6 +1,10 @@
 <?php
 namespace HeyPublisher;
 
+if (!class_exists("\HeyPublisher\Base\Log")) {
+  require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/Log.class.php');
+}
+
 if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('HeyPublisher: Illegal Page Call!'); }
 
 /**
@@ -9,9 +13,9 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('HeyP
 */
 class Base {
   var $debug = true;
+  var $logger = null;
   var $help = false;
   var $i18n = 'heypublisher';  // key for internationalization stubs
-  var $log_file = '';
   var $plugin = array(
     'url' => 'https://www.heypublisher.com',
     'home' => 'https://wordpress.org/plugins/',
@@ -22,9 +26,11 @@ class Base {
   var $slug = '';   // should be defined in constructor of any class that extends this class.
 
   public function __construct() {
+    global $HEYPUB_LOGGER;
     // this can't be instantiated in var declaration
     // $this->plugin['url'] = plugins_url('../../',__FILE__);
-    $this->log_file = dirname( __FILE__ ) . '/../../../error.log';
+    $this->logger = $HEYPUB_LOGGER;
+    $this->logger->debug("HeyPublisher::Base loaded");
   }
 
   public function __destruct() {
@@ -59,15 +65,6 @@ EOF;
 EOF;
     return $text;
 	}
-
-  /**
-   * Logging function
-   */
-  public function log($msg) {
-    if ($this->debug && $this->log_file) {
-      error_log(sprintf("%s\n",$msg),3,$this->log_file);
-    }
-  }
 
   /**
    * Style the side-bar link appropriately

--- a/include/classes/HeyPublisher/Base/Log.class.php
+++ b/include/classes/HeyPublisher/Base/Log.class.php
@@ -1,0 +1,39 @@
+<?php
+// Generic logging class.
+// Should be instantiated: $this->logger = new \NAMESPACE\HeyPublisher\Log('file.log');
+// Then send logs: $this->logger->debug("message"); and it will be written to 'file.log'
+
+namespace HeyPublisher\Base;
+
+if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('HeyPublisher: Illegal Page Call!'); }
+
+// Logging class for all HeyPublisher plugins.
+// Should be instantiated in main plugin file using global var $HEYPUB_LOGGER
+class Log {
+  var $enable = false;
+  var $log_file = '';
+
+  // Pass in fully pathed file if you want to override default
+  public function __construct($file='') {
+    if (!$file) { $file = '/tmp/heypub_plugin_error.log'; }
+    // this can't be instantiated in var declaration
+    $this->log_file = $file;
+    if (file_exists($this->log_file)) {
+      // can only turn on logging if server-side environment exists
+      $this->enable = (getenv('HEYPUB_DEBUG') === 'true');
+    }
+  }
+
+  // Logging function
+  public function debug($msg) {
+    if ($this->enable) {
+      error_log(sprintf("%s\n",$msg),3,$this->log_file);
+    }
+  }
+}
+// This class sets a global accessor
+if (!isset($HEYPUB_LOGGER)) {
+  $HEYPUB_LOGGER  = new \HeyPublisher\Base\Log();
+  $HEYPUB_LOGGER->debug("Instantiating HeyPublisher\Base\Log...");
+}
+?>

--- a/include/classes/HeyPublisher/Base/Log.class.php
+++ b/include/classes/HeyPublisher/Base/Log.class.php
@@ -1,6 +1,6 @@
 <?php
 // Generic logging class.
-// Should be instantiated: $this->logger = new \NAMESPACE\HeyPublisher\Log('file.log');
+// Should be instantiated: $this->logger = new \HeyPublisher\Base\Log('file.log');
 // Then send logs: $this->logger->debug("message"); and it will be written to 'file.log'
 
 namespace HeyPublisher\Base;
@@ -8,7 +8,8 @@ namespace HeyPublisher\Base;
 if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('HeyPublisher: Illegal Page Call!'); }
 
 // Logging class for all HeyPublisher plugins.
-// Should be instantiated in main plugin file using global var $HEYPUB_LOGGER
+// This class is instantiated automatically when loaded and will be accessible
+// via the global $HEYPUB_LOGGER
 class Log {
   var $enable = false;
   var $log_file = '';

--- a/include/classes/HeyPublisher/Base/Updater.class.php
+++ b/include/classes/HeyPublisher/Base/Updater.class.php
@@ -22,7 +22,7 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('HeyP
 // $hp_updater->set_username( 'NOt-HeyPublisher' ); // Only use this setter if plugin not hosted by 'HeyPublisher'
 // $hp_updater->set_repository( 'this-plugin-repo' ); // set repo
 // $hp_updater->initialize('vesion-tested'); // initialize the updater.
-// 
+//
 // The 'version-tested' is a string that allows you to display through which
 // version of WordPress this plugin has been tested through.
 // If the user's version is greater  than this version, they will get a
@@ -151,8 +151,8 @@ class Updater {
 					'slug'				=> $this->basename,
 					'requires'		=> $this->plugin["RequiresWP"],
 					'tested'			=> $this->tested_to,
-					'rating'			=> '90.0',
-					'num_ratings'	=> '23',
+					// 'rating'			=> '90.0',  /// need to figure out how to get this from github
+					// 'num_ratings'	=> '23',  /// need to figure out how to get this from github
 					'downloaded'	=> '8669',
 					'added'				=> '2016-01-05',
 					'version'			=> $this->github_response['tag_name'],

--- a/include/classes/HeyPublisher/Base/Updater.class.php
+++ b/include/classes/HeyPublisher/Base/Updater.class.php
@@ -1,0 +1,193 @@
+<?php
+
+// https://www.smashingmagazine.com/2015/08/deploy-wordpress-plugins-with-github-using-transients/
+// https://code.tutsplus.com/tutorials/distributing-your-plugins-in-github-with-automatic-updates--wp-34817
+// TODO: better organize this code
+
+namespace HeyPublisher\Base;
+
+if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('HeyPublisher: Illegal Page Call!'); }
+
+// Updater class for all HeyPublisher plugins.
+// This class should be included in plugins that are hosted on github.com/HeyPublisher
+//
+// This class should be loaded into the plugin main.php file only
+//  if (!class_exists("\HeyPublisher\Base\Updater")) {
+//    require_once(<PLUGIN_FULLPATH> . '/include/classes/HeyPublisher/Base/Updater.class.php');
+//  }
+// When loaded, it will NOT automatically be instantiated, as that would prevent multiple plugins from instantiating individually.
+// You will need to assign to a LOCAL variable to avoid overwriting the updater for other HeyPublsher plugins
+//
+// $hp_updater = new HeyPublisherUpdater( __FILE__ ); // instantiate our class
+// $hp_updater->set_username( 'NOt-HeyPublisher' ); // Only use this setter if plugin not hosted by 'HeyPublisher'
+// $hp_updater->set_repository( 'this-plugin-repo' ); // set repo
+// $hp_updater->initialize('vesion-tested'); // initialize the updater.
+// 
+// The 'version-tested' is a string that allows you to display through which
+// version of WordPress this plugin has been tested through.
+// If the user's version is greater  than this version, they will get a
+// warning about plugin not having been tested through their version.
+
+class Updater {
+
+  private $file;
+	private $plugin;
+	private $basename;
+	private $active;
+	private $username;
+	private $repository;
+	private $authorize_token;
+	private $github_response;
+  private $tested_to = 1.0;
+
+	public function __construct( $file ) {
+
+		$this->file = $file;
+    $this->username = 'HeyPublisher';
+
+		add_action( 'admin_init', array( $this, 'set_plugin_properties' ) );
+
+		return $this;
+	}
+
+	public function set_plugin_properties() {
+		$this->plugin	= get_plugin_data( $this->file );
+		$this->basename = plugin_basename( $this->file );
+		$this->active	= is_plugin_active( $this->basename );
+	}
+
+	public function set_username( $username ) {
+		$this->username = $username;
+	}
+
+	public function set_repository( $repository ) {
+		$this->repository = $repository;
+	}
+
+	public function authorize( $token ) {
+		$this->authorize_token = $token;
+	}
+
+  // Get the info about version from the repository
+	private function get_repository_info() {
+	    if ( is_null( $this->github_response ) ) { // Do we have a response?
+	        $request_uri = sprintf( 'https://api.github.com/repos/%s/%s/releases', $this->username, $this->repository ); // Build URI
+
+	        if( $this->authorize_token ) { // Is there an access token?
+	            $request_uri = add_query_arg( 'access_token', $this->authorize_token, $request_uri ); // Append it
+	        }
+
+	        $response = json_decode( wp_remote_retrieve_body( wp_remote_get( $request_uri ) ), true ); // Get JSON and parse it
+
+	        if( is_array( $response ) ) { // If it is an array
+	            $response = current( $response ); // Get the first item
+	        }
+
+	        if( $this->authorize_token ) { // Is there an access token?
+	            $response['zipball_url'] = add_query_arg( 'access_token', $this->authorize_token, $response['zipball_url'] ); // Update our zip url with token
+	        }
+
+	        $this->github_response = $response; // Set it to our property
+	    }
+	}
+
+  // Ties into the WP transients
+  // This is where we put conditions for paid versions of plugin
+	public function initialize($tested=null) {
+		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'modify_transient' ), 10, 1 );
+		add_filter( 'plugins_api', array( $this, 'plugin_popup' ), 10, 3);
+		add_filter( 'upgrader_post_install', array( $this, 'after_install' ), 10, 3 );
+    if (!is_null($tested)) {
+      $this->tested_to = $tested;
+    }
+	}
+
+  // This tests to see if there is a later version on GitHub
+  // If the release on GitHub is greater, we get the upgrade prompt
+	public function modify_transient( $transient ) {
+
+		if( property_exists( $transient, 'checked') ) { // Check if transient has a checked property
+
+			if( $checked = $transient->checked ) { // Did Wordpress check for updates?
+
+				$this->get_repository_info(); // Get the repo info
+
+				$out_of_date = version_compare( $this->github_response['tag_name'], $checked[ $this->basename ], 'gt' ); // Check if we're out of date
+
+				if( $out_of_date ) {
+
+					$new_files = $this->github_response['zipball_url']; // Get the ZIP
+
+					$slug = current( explode('/', $this->basename ) ); // Create valid slug
+
+					$plugin = array( // setup our plugin info
+						'url' => $this->plugin["PluginURI"],
+						'slug' => $slug,
+						'package' => $new_files,
+						'new_version' => $this->github_response['tag_name']
+					);
+
+					$transient->response[$this->basename] = (object) $plugin; // Return it in response
+				}
+			}
+		}
+
+		return $transient; // Return filtered transient
+	}
+
+  // This displays the popup prompt and shows info about the plugin hosted on GitHub.
+  //
+	public function plugin_popup( $result, $action, $args ) {
+
+		if( ! empty( $args->slug ) ) { // If there is a slug
+
+			if( $args->slug == current( explode( '/' , $this->basename ) ) ) { // And it's our slug
+
+				$this->get_repository_info(); // Get our repo info
+
+				// Set it to an array
+				$plugin = array(
+					'name'				=> $this->plugin["Name"],
+					'slug'				=> $this->basename,
+					'requires'		=> $this->plugin["RequiresWP"],
+					'tested'			=> $this->tested_to,
+					'rating'			=> '90.0',
+					'num_ratings'	=> '23',
+					'downloaded'	=> '8669',
+					'added'				=> '2016-01-05',
+					'version'			=> $this->github_response['tag_name'],
+					'author'			=> $this->plugin["AuthorName"],
+					'author_profile'	=> $this->plugin["AuthorURI"],
+					'last_updated'		=> $this->github_response['published_at'],
+					'homepage'		=> $this->plugin["PluginURI"],
+					'short_description' => $this->plugin["Description"],
+					'sections'		=> array(
+						'Description'	  => $this->plugin["Description"],
+						'Updates'		    => $this->github_response['body'],
+					),
+					'download_link'	=> $this->github_response['zipball_url']
+				);
+
+				return (object) $plugin; // Return the data
+			}
+
+		}
+		return $result; // Otherwise return default
+	}
+
+	public function after_install( $response, $hook_extra, $result ) {
+		global $wp_filesystem; // Get global FS object
+
+		$install_directory = plugin_dir_path( $this->file ); // Our plugin directory
+		$wp_filesystem->move( $result['destination'], $install_directory ); // Move files to the plugin dir
+		$result['destination'] = $install_directory; // Set the destination for the rest of the stack
+
+		if ( $this->active ) { // If it was active
+			activate_plugin( $this->basename ); // Reactivate
+		}
+
+		return $result;
+	}
+}
+
+?>

--- a/include/classes/SGW_Widget.class.php
+++ b/include/classes/SGW_Widget.class.php
@@ -1,15 +1,18 @@
 <?php
 /*
   Widget Class
-  http://codex.wordpress.org/Widgets_API
+  https://codex.wordpress.org/Widgets_API
 */
 class SupportGreatWriters extends WP_Widget {
   var $seen = array();
   var $options = array();
   var $asins = array();
-
+  var $logger = null;
 
 	function __construct() {
+    global $HEYPUB_LOGGER;
+    $this->logger = $HEYPUB_LOGGER;
+    $this->logger->debug("SupportGreatWriters");
 		$control_ops = array( 'id_base' => 'sgw' );
 		$widget_ops = array('description' => __('Easily sell Amazon books or other products in sidebar.','sgw'));
 		$this->options = get_option(SGW_PLUGIN_OPTTIONS);
@@ -17,6 +20,8 @@ class SupportGreatWriters extends WP_Widget {
 	}
 
   // Get the amazon link for a passed-in ASIN and Associates ID
+  // TODO: switch this to calling HeyPublisher.com server to get data, as the
+  // secure URL for images can only be calculated using application key and secret
   function get_amazon_link($asin,$assoc,$country) {
     $url_map = array(
       'com'     => 'amazon.com',
@@ -32,7 +37,7 @@ class SupportGreatWriters extends WP_Widget {
       // display default image
       $link = sprintf('<img src="%s" title="Product ASIN not defined">',SGW_DEFAULT_IMAGE);
     } else {
-      $format = '<a title="Click for more Information" target=_blank href="http://www.%s/gp/product/%s?ie=UTF8&tag=%s&linkCode=as2&camp=1789&creative=9325&creativeASIN=%s"><img class="sgw_product_img" src="http://ecx.images-amazon.com/images/P/%s.01._SCMZZZZZZZ_.jpg"></a><img src="http://www.assoc-%s/e/ir?t=%s&l=as2&o=1&a=%s" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" />';
+      $format = '<a title="Click for more Information" target=_blank href="https://www.%s/gp/product/%s?ie=UTF8&tag=%s&linkCode=as2&camp=1789&creative=9325&creativeASIN=%s"><img class="sgw_product_img" src="http://ecx.images-amazon.com/images/P/%s.01._SCMZZZZZZZ_.jpg"></a><img src="https://www.assoc-%s/e/ir?t=%s&l=as2&o=1&a=%s" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" />';
       $link = sprintf($format,$url_map[$country],$asin,$assoc,$asin,$asin,$url_map[$country],$assoc,$asin);
     }
     return $link;
@@ -40,9 +45,10 @@ class SupportGreatWriters extends WP_Widget {
 
   // Split a comma-separated list of asins apart and return an array of POST or DEFAULT asins for display.
   private function shuffle_asin_list($list) {
+    $this->logger->debug(sprintf("\tshuffle_asin_list : \n\t\$list = %s",print_r($list,1)));
     $asins = array();
     if ($list) {
-  	  $array = split(',',$list);
+  	  $array = explode(',',$list);
   	  shuffle($array);
       return $array;
     }

--- a/license.txt
+++ b/license.txt
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/readme.txt
+++ b/readme.txt
@@ -51,10 +51,12 @@ If you wish to make a donation, please consider donating instead to the [Literar
 == Changelog ==
 
 = 3.0.0 =
-* Released: 2020-06-29
+* Released: 2020-07-03
 * Plugin is now hosted on [GitHub](https://github.com/HeyPublisher/amazon-book-store)
 * Fixed issue with call to function `split` not being found in PHP versions 7.0 and above.
-
+* Added an updater that will check GitHub for latest version and update locally.
+* Organized code around HeyPublisher/Base class
+* Validated plugin works up through WordPress 5.3
 
 = 2.2.1 =
 * Released: 2017-05-27

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: heypublisher, aguywithanidea, loudlever
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=Y8SL68GN5J2PL
 Tags: affiliate, amazon, product, book store, affiliate sales,ASIN, Amazon Associate, monetize, heypublisher
 Requires at least: 4.0
-Tested up to: 4.7.3
-Stable tag: 2.2.1
+Tested up to: 5.3.0
+Stable tag: 3.0.0
 License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Sell Amazon products in sidebar widgets, unique to the individual POST or generically from a default pool of products that you define.
 
@@ -28,7 +28,7 @@ Install the plugin, then activate it.  Once activated, configure the Widget:
 
 **Configure the ASIN pool**
 
-Navigate to 'Settings' -> 'Amazon Book Store'.  Input your Amazon Affiliate ID and country, the add the ASINs for the products you want to be displayed in the widget.  See [How to Find Amazon ASINs](http://askville.amazon.com/find-Amazon-ASIN-product-details-page/AnswerViewer.do?requestId=11106037) for more information.  There are two categorizations of settings:
+Navigate to 'Settings' -> 'Amazon Book Store'.  Input your Amazon Affiliate ID and country, the add the ASINs for the products you want to be displayed in the widget.  See [How to Find Amazon ASINs](https://www.amazon.com/gp/seller/asin-upc-isbn-info.html) for more information.  There are two categorizations of settings:
 
 * POST Specific:  If set, these products will be displayed when users are reading the designated POST.
 * Default: If the request is to a POST that does not have specific ASINs defined, then the widget will display products from this group.
@@ -49,6 +49,12 @@ If you wish to make a donation, please consider donating instead to the [Literar
 4. ASIN configuration for POSTs and for Default pool
 
 == Changelog ==
+
+= 3.0.0 =
+* Released: 2020-06-29
+* Plugin is now hosted on [GitHub](https://github.com/HeyPublisher/amazon-book-store)
+* Fixed issue with call to function `split` not being found in PHP versions 7.0 and above.
+
 
 = 2.2.1 =
 * Released: 2017-05-27
@@ -105,7 +111,7 @@ If you wish to make a donation, please consider donating instead to the [Literar
 
 = 1.0.1 =
 * Updated screenshots to highlight the fact that users should change their Amazon Associate ID.
-* Plugin is now owned and maintained by [Loudlever, Inc.](http://www.loudlever.com)
+* Plugin is now owned and maintained by [Loudlever, Inc.](https://www.loudlever.com)
 * Update Release (03/26/2010)
 
 = 1.0 =

--- a/support_great_writers.php
+++ b/support_great_writers.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/plugins/support-great-writers/
 Description: Sell Amazon products in sidebar widgets, unique to the individual POST or generically from a default pool of products that you define.
 Author: HeyPublisher
 Author URI: https://www.heypublisher.com
-Version: 2.1.0
+Version: 3.0.0
 Requires at least: 5.0
 
   Copyright 2009-2014 Loudlever (wordpress@loudlever.com)

--- a/support_great_writers.php
+++ b/support_great_writers.php
@@ -5,7 +5,8 @@ Plugin URI: https://wordpress.org/plugins/support-great-writers/
 Description: Sell Amazon products in sidebar widgets, unique to the individual POST or generically from a default pool of products that you define.
 Author: HeyPublisher
 Author URI: https://www.heypublisher.com
-Version: 3.0.0
+Version: 2.1.0
+Requires at least: 5.0
 
   Copyright 2009-2014 Loudlever (wordpress@loudlever.com)
   Copyright 2014-2017 Richard Luck (https://github.com/aguywithanidea/)
@@ -54,7 +55,11 @@ if ($debug) {
   define('SGW_DEBUG',false);
 }
 
+// Configs specific to the plugin
 define('SGW_PLUGIN_VERSION', '3.0.0');
+define('SGW_PLUGIN_TESTED', '5.3.0');
+
+
 define('SGW_PLUGIN_OPTTIONS', '_sgw_plugin_options');
 define('SGW_BASE_URL', get_option('siteurl').'/wp-content/plugins/support-great-writers/');
 define('SGW_DEFAULT_IMAGE', get_option('siteurl').'/wp-content/plugins/support-great-writers/images/not_found.gif');
@@ -62,6 +67,7 @@ define('SGW_POST_META_KEY','SGW_ASIN');
 define('SGW_ADMIN_PAGE','amazon_bookstore');
 define('SGW_ADMIN_PAGE_NONCE','sgw-save-options');
 define('SGW_PLUGIN_ERROR_CONTACT','Please contact <a href="mailto:wordpress@heypublisher.com?subject=Amazon%20Bookstore%20Widget">wordpress@heypublisher.com</a> if you have any questions');
+// Modify the defaults to show
 define('SGW_BESTSELLERS','1455570249,144947425X,1501164589,0692859055');
 define('SGW_PLUGIN_FILE',plugin_basename(__FILE__));
 define('SGW_PLUGIN_FULLPATH', dirname(__FILE__));
@@ -69,6 +75,13 @@ define('SGW_PLUGIN_FULLPATH', dirname(__FILE__));
 if (!class_exists("\HeyPublisher\Base\Log")) {
   require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/Log.class.php');
 }
+if (!class_exists("\HeyPublisher\Base\Updater")) {
+  require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/Updater.class.php');
+}
+// initialize the updater and test for update
+$sgw_updater = new \HeyPublisher\Base\Updater( __FILE__ );
+$sgw_updater->set_repository( 'amazon-book-store' ); // set repo
+$sgw_updater->initialize(SGW_PLUGIN_TESTED); // initialize the updater
 
 require_once(dirname(__FILE__) . '/include/classes/SGW_Widget.class.php');
 require_once(dirname( __FILE__ ) . '/include/classes/AMZNBS/Admin.class.php');

--- a/support_great_writers.php
+++ b/support_great_writers.php
@@ -5,11 +5,11 @@ Plugin URI: https://wordpress.org/plugins/support-great-writers/
 Description: Sell Amazon products in sidebar widgets, unique to the individual POST or generically from a default pool of products that you define.
 Author: HeyPublisher
 Author URI: https://www.heypublisher.com
-Version: 2.2.1
+Version: 3.0.0
 
   Copyright 2009-2014 Loudlever (wordpress@loudlever.com)
   Copyright 2014-2017 Richard Luck (https://github.com/aguywithanidea/)
-  Copyright 2017 HeyPublisher (https://www.heypublisher.com/)
+  Copyright 2017-2020 HeyPublisher (https://www.heypublisher.com/)
 
   Permission is hereby granted, free of charge, to any person
   obtaining a copy of this software and associated documentation
@@ -45,9 +45,16 @@ if ( !function_exists( 'add_action' ) ) {
   OPTION SETTINGS
 ---------------------------------------------------------------------------------
 */
+global $HEYPUB_LOGGER;
 
-define('SGW_DEBUG',false);
-define('SGW_PLUGIN_VERSION', '2.2.1');
+$debug = (getenv('HEYPUB_DEBUG') === 'true');
+if ($debug) {
+  define('SGW_DEBUG',true);
+} else {
+  define('SGW_DEBUG',false);
+}
+
+define('SGW_PLUGIN_VERSION', '3.0.0');
 define('SGW_PLUGIN_OPTTIONS', '_sgw_plugin_options');
 define('SGW_BASE_URL', get_option('siteurl').'/wp-content/plugins/support-great-writers/');
 define('SGW_DEFAULT_IMAGE', get_option('siteurl').'/wp-content/plugins/support-great-writers/images/not_found.gif');
@@ -57,6 +64,11 @@ define('SGW_ADMIN_PAGE_NONCE','sgw-save-options');
 define('SGW_PLUGIN_ERROR_CONTACT','Please contact <a href="mailto:wordpress@heypublisher.com?subject=Amazon%20Bookstore%20Widget">wordpress@heypublisher.com</a> if you have any questions');
 define('SGW_BESTSELLERS','1455570249,144947425X,1501164589,0692859055');
 define('SGW_PLUGIN_FILE',plugin_basename(__FILE__));
+define('SGW_PLUGIN_FULLPATH', dirname(__FILE__));
+
+if (!class_exists("\HeyPublisher\Base\Log")) {
+  require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/Log.class.php');
+}
 
 require_once(dirname(__FILE__) . '/include/classes/SGW_Widget.class.php');
 require_once(dirname( __FILE__ ) . '/include/classes/AMZNBS/Admin.class.php');


### PR DESCRIPTION
Moving away from WordPress.org hosting and to Github hosting, as Git is the scm for this plugin anyway.

Additional changes include:
+ Adding an updater to the HeyPublisher/Base namespace to be used by this and other GitHub-hosted HeyPublisher plugins
+ Updated all reference to `http` to `https` where found.  This leaves a gap in the non-secure image urls from Amazon, which will be solved in the next minor version update as the HeyPublisher API calls are introduced to this plugin to ease fetching images.
+ Changed the logger to use the new HeyPublisher/Base/Log class.  Updated all logger calls to use this new class.
