### PR TITLE
Updating to fetch ASINs from HeyPublisher `api/asins` endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# ignore our control file
+difflist
+error.log
+
+# ignore the svn control files
+.svn

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ error.log
 
 # ignore the svn control files
 .svn
+_NOTES.txt

--- a/include/classes/AMZNBS/ASIN.class.php
+++ b/include/classes/AMZNBS/ASIN.class.php
@@ -1,0 +1,45 @@
+<?php
+namespace AMZNBS;
+
+// ASIN API Wrapper
+//
+// This class enables fetching ASIN info from the API when not cached locally
+
+if (!class_exists("\HeyPublisher\Base\API")) {
+  require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/API.class.php');
+}
+
+class ASIN extends \HeyPublisher\Base\API {
+
+  public function __construct() {
+    parent::__construct();
+    $this->logger->debug("ASIN#__construct()");
+    // TODO: to make this generic, the uoid and poid need to be dynamic
+    // If HeyPublisher submission manager is installed, use those, else use plugin defaults
+    // global $HEYPUB_LOGGER;
+    // $this->logger = $HEYPUB_LOGGER;
+    // $this->logger->debug("HeyPublisher::API loaded");
+    // $this->initialize_api_url();
+    // $this->initialize_oids();
+  }
+
+  public function fetch_asin($asin) {
+    $path = sprintf('asins/%s',$asin);
+    $result = $this->get($path);
+    if ($result && key_exists('object',$result) && $result['object'] == 'asin' ) {
+      $obj = array(
+        'title' => $result['title'],
+        'image' => $result['image']
+      );
+      return $obj;
+    }
+    return;
+  }
+
+}
+
+// This class sets a global accessor
+if (!isset($SGW_API)) {
+  $SGW_API  = new \AMZNBS\ASIN();
+}
+?>

--- a/include/classes/AMZNBS/ASIN.class.php
+++ b/include/classes/AMZNBS/ASIN.class.php
@@ -9,10 +9,15 @@ if (!class_exists("\HeyPublisher\Base\API")) {
   require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/API.class.php');
 }
 
-class ASIN extends \HeyPublisher\Base\API {
+class ASIN {
+  var $api = null;
+  var $logger = null;
 
   public function __construct() {
-    parent::__construct();
+    // don't extend the API class to prevent from getting instantiated multiple times
+    global $HEYPUB_API;
+    $this->api = $HEYPUB_API;
+    $this->logger = $HEYPUB_API->logger;
     $this->logger->debug("ASIN#__construct()");
   }
 
@@ -20,9 +25,10 @@ class ASIN extends \HeyPublisher\Base\API {
   public function fetch_asins($list) {
     $data = array();
     $path = sprintf('asins/%s',$list);
-    $result = $this->get($path);
+    $result = $this->api->get($path);
     if ($result && key_exists('object',$result) && $result['object'] == 'list' ) {
-      foreach ($result['data'] as $asin=>$hash) {
+      foreach ($result['data'] as $hash) {
+        $asin = sprintf("ASIN_%s",$hash['id']);
         $data[$asin] = array(
           'title' => $hash['title'],
           'image' => $hash['image'],

--- a/include/classes/AMZNBS/ASIN.class.php
+++ b/include/classes/AMZNBS/ASIN.class.php
@@ -15,9 +15,9 @@ class ASIN {
 
   public function __construct() {
     // don't extend the API class to prevent from getting instantiated multiple times
-    global $HEYPUB_API;
+    global $HEYPUB_API, $HEYPUB_LOGGER;
     $this->api = $HEYPUB_API;
-    $this->logger = $HEYPUB_API->logger;
+    $this->logger = $HEYPUB_LOGGER;
     $this->logger->debug("ASIN#__construct()");
   }
 

--- a/include/classes/AMZNBS/ASIN.class.php
+++ b/include/classes/AMZNBS/ASIN.class.php
@@ -14,24 +14,21 @@ class ASIN extends \HeyPublisher\Base\API {
   public function __construct() {
     parent::__construct();
     $this->logger->debug("ASIN#__construct()");
-    // TODO: to make this generic, the uoid and poid need to be dynamic
-    // If HeyPublisher submission manager is installed, use those, else use plugin defaults
-    // global $HEYPUB_LOGGER;
-    // $this->logger = $HEYPUB_LOGGER;
-    // $this->logger->debug("HeyPublisher::API loaded");
-    // $this->initialize_api_url();
-    // $this->initialize_oids();
   }
 
-  public function fetch_asin($asin) {
-    $path = sprintf('asins/%s',$asin);
+  // Fetch 'n' number of asins from comma-separated list
+  public function fetch_asins($list) {
+    $data = array();
+    $path = sprintf('asins/%s',$list);
     $result = $this->get($path);
-    if ($result && key_exists('object',$result) && $result['object'] == 'asin' ) {
-      $obj = array(
-        'title' => $result['title'],
-        'image' => $result['image']
-      );
-      return $obj;
+    if ($result && key_exists('object',$result) && $result['object'] == 'list' ) {
+      foreach ($result['data'] as $asin=>$hash) {
+        $data[$asin] = array(
+          'title' => $hash['title'],
+          'image' => $hash['image'],
+        );
+      }
+      return $data;
     }
     return;
   }

--- a/include/classes/AMZNBS/Admin.class.php
+++ b/include/classes/AMZNBS/Admin.class.php
@@ -8,7 +8,7 @@ namespace AMZNBS;
 
 */
 if (!class_exists('\HeyPublisher\Base')) {
-  load_template(dirname( __FILE__ ) . '/../HeyPublisher/Base.class.php');
+  require_once( dirname(__FILE__) . '/../HeyPublisher/Base.class.php');
 }
 class Admin extends \HeyPublisher\Base {
 
@@ -414,8 +414,12 @@ EOF;
         </ul>
         <p>
           If you want specific products to display on individual pages, add those product ASINs here.
+        </p>
+        <p>
           Select the POST from the drop-down list below then input the desired ASINs as a
           comma-separated list.  You can add as many or as few as you like.
+        </p>
+        <p>
           You can also set the ASINs in the Post Edit page by using the custom field
           <code>{$this->post_meta_key}</code>.
         </p>

--- a/include/classes/AMZNBS/Admin.class.php
+++ b/include/classes/AMZNBS/Admin.class.php
@@ -161,6 +161,8 @@ class Admin extends \HeyPublisher\Base {
         'version_current' => null,
         'install_date'    => null,
         'upgrade_date'    => null),
+      'affiliate_id'      => 'pif-richard-20',  // default or things break
+      'country_id'        => 'com',       // default
       'default' => null,
       'dynamic' => array(),
       'default_meta' => array()
@@ -226,6 +228,7 @@ class Admin extends \HeyPublisher\Base {
 
   public function supported_countries() {
     $countries = array(
+      'br' => 'Brazil (amazon.com.br)',
       'ca' => 'Canada (amazon.ca)',
       'fr' => 'France (amazon.fr)',
       'de' => 'Germany (amazon.de)',
@@ -460,6 +463,7 @@ EOF;
       <form method="post" action="admin.php?page={$this->nav_slug}">
         {$nonce}
   			<p>Add the widget to your side-bar and configure which products you want to sell using the form below.</p>
+        <p>Ensure your Affiliate ID is accurate. A default ID may be displayed below so that the plugin works while you are testing.</p>
         <ul>
           <li>
             <label class='sgw_label' for='amznbs_country_id'>Affiliate Country</label>

--- a/include/classes/AMZNBS/Admin.class.php
+++ b/include/classes/AMZNBS/Admin.class.php
@@ -254,15 +254,11 @@ class Admin extends \HeyPublisher\Base {
         $this->options['country_id'] = $opts['country_id'];
 
         $this->update_default_asins($opts['default']);
-        // $this->update_new_asins($opts['new']);
-        // $this->update_existing_asins($opts['posts']);
 
         // update the newly added ASINs
         if ($opts['new']) {
           foreach ($opts['new'] as $id=>$hash) {
             if ($test = $this->normalize_asin_list($hash['asin'])) {
-              // TODO: Hook into this to pre-fetch Images for the listed ASINs, but we want to store in meta as a hash that can be unpacked
-              // with a key that begins with underbar, so it's hidden.
               add_post_meta($id,SGW_POST_META_KEY,$test,true) or update_post_meta($id,SGW_POST_META_KEY,$test);
 							$message = "Your updates have been saved.";
             } else {

--- a/include/classes/AMZNBS/Admin.class.php
+++ b/include/classes/AMZNBS/Admin.class.php
@@ -290,16 +290,18 @@ class Admin extends \HeyPublisher\Base {
   private function fetch_asin_meta_data($list,$meta) {
     global $SGW_API;
     $newmeta = array();
+    $need = array();
     $array = explode(',',$list);
     foreach ($array as $asin) {
       if (isset($meta[$asin])) {
         $newmeta[$asin] = $meta[$asin];
       } else {
-        // need to fetch the ASIN meta data
-        $data = $SGW_API->fetch_asin($asin);
-        if ($data) {
-          $newmeta[$asin] = $data;
-        }
+        array_push($need,$asin);
+      }
+      $fetch = join(',',$need);
+      $data = $SGW_API->fetch_asins($fetch);
+      if ($data) {
+        array_merge($newmeta,$data);
       }
     }
     $this->logger->debug(sprintf("Admin#fetch_asin_meta_data()\n\t\$newmeta = %s",print_r($newmeta,1)));

--- a/include/classes/AMZNBS/Admin.class.php
+++ b/include/classes/AMZNBS/Admin.class.php
@@ -287,7 +287,7 @@ class Admin extends \HeyPublisher\Base {
       return $message;
     }
   }
-  private function fetch_asin_meta_data($list,$meta) {
+  public function fetch_asin_meta_data($list,$meta) {
     global $SGW_API;
     $newmeta = array();
     $need = array();

--- a/include/classes/HeyPublisher/API.class.php
+++ b/include/classes/HeyPublisher/API.class.php
@@ -1,0 +1,236 @@
+<?php
+namespace HeyPublisher;
+
+if (!class_exists("\HeyPublisher\Base\Log")) {
+  require_once( dirname(__FILE__) . '/Base/Log.class.php');
+}
+
+if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('HeyPublisher: Illegal Page Call!'); }
+
+/**
+ * HeyPublisher base class for all JSON API calls
+ * TODO: https://stackoverflow.com/questions/13420952/php-curl-delete-request
+ * Clean up this file to be more DRY
+ */
+
+class API {
+  var $debug = false;
+  var $api = HEYPUB_API;
+  var $error = false;
+  var $timeout = 4;
+  var $config = null;
+  var $uoid = '';
+  var $poid = '';
+
+  public function __construct() {
+    global $hp_config;
+    $this->config = $hp_config;
+    $this->uoid = $hp_config->uoid;
+    $this->poid = $hp_config->poid;
+    $this->logger = $hp_config->logger;
+    $this->logger->debug("API#__construct");
+    register_shutdown_function(array($this,'shutdown'));
+  }
+
+  public function __destruct() {
+
+  }
+
+  // Register the shutdown functions
+  public function shutdown() {
+    $this->logger->debug("API#shutdown");
+    // https://stackoverflow.com/questions/33231656/register-static-class-method-as-shutdown-function-in-php
+    // https://us.php.net/manual/en/function.register-shutdown-function.php
+    // curl_close($this->curl);
+  }
+
+  /**
+  * Send a POST requst using cURL
+  * @param string $url to request
+  * @param array $post values to send
+  * @param array $options for cURL
+  * @return string
+  */
+  public function post($path, array $post = NULL, array $options = array()) {
+    $url = sprintf('%s/%s',$this->api,$path);
+    $post = $this->clean_post_vars($post);
+    $defaults = array(
+      CURLOPT_POST => 1,
+      CURLOPT_HEADER => 0,
+      CURLOPT_URL => $url,
+      CURLOPT_FRESH_CONNECT => 1,
+      CURLOPT_RETURNTRANSFER => 1,
+      CURLOPT_FORBID_REUSE => 1,
+      CURLOPT_TIMEOUT => $this->timeout,
+      CURLOPT_POSTFIELDS => http_build_query($post)
+    );
+    $curl = curl_init();
+    curl_setopt_array($curl, ($options + $defaults) );
+    $result = $this->send($curl);
+    curl_close($curl);
+    return $result;
+  }
+
+  /**
+  * Send a GET requst using cURL
+  * @param string $url to request
+  * @param array $get values to send
+  * @param array $options for cURL
+  * @return string
+  */
+  public function get($path, array $get = NULL, array $options = array()) {
+    if ($get === NULL ) { $get = array(); }
+    $this->logger->debug("in get()\n\tpath: {$path}");
+    $this->logger->debug(sprintf("\tget: %s", print_r($get,1)));
+    $url = sprintf('%s/%s',$this->api,$path);
+    $this->logger->debug("=> url: {$url}");
+    $defaults = array(
+      CURLOPT_URL => $url. (strpos($url, '?') === FALSE ? '?' : ''). http_build_query($get),
+      CURLOPT_HEADER => 0,
+      CURLOPT_RETURNTRANSFER => TRUE,
+      CURLOPT_TIMEOUT => $this->timeout
+    );
+    $curl = curl_init();
+    curl_setopt_array($curl, ($options + $defaults) );
+    $result = $this->send($curl);
+    curl_close($curl);
+    return $result;
+  }
+
+  /**
+  * Send a PUT requst using cURL
+  * @param string $url to request
+  * @param array $put values to send
+  * @param array $options for cURL
+  * @return string
+  */
+  public function put($path, array $put = NULL, array $options = array()) {
+    $url = sprintf('%s/%s',$this->api,$path);
+    $this->logger->debug("in put()\n\tpath: {$path}");
+    $this->logger->debug(sprintf("\tput: %s", print_r($put,1)));
+    $data = $this->clean_post_vars($put);
+    $defaults = array(
+      CURLOPT_URL => $url,
+      CURLOPT_FRESH_CONNECT => 1,
+      CURLOPT_RETURNTRANSFER => 1,
+      CURLOPT_FORBID_REUSE => 1,
+      CURLOPT_TIMEOUT => $this->timeout,
+      CURLOPT_CUSTOMREQUEST   => 'PUT',
+      CURLOPT_POSTFIELDS => http_build_query($data),
+      CURLOPT_HEADER => 0
+    );
+    $curl = curl_init();
+    curl_setopt_array($curl, ($options + $defaults) );
+    $result = $this->send($curl,'updated');
+    curl_close($curl);
+    return $result;
+  }
+
+  /**
+  * Send a GET requst using cURL
+  * @param string $url to request
+  * @return string
+  */
+  public function delete($path) {
+    $this->logger->debug("in delete()\n\tpath: {$path}");
+    $url = sprintf('%s/%s',$this->api,$path);
+    $this->logger->debug("=> url: {$url}");
+    $defaults = array(
+      CURLOPT_URL => $url,
+      CURLOPT_HEADER => 0,
+      CURLOPT_RETURNTRANSFER  => TRUE,
+      CURLOPT_CUSTOMREQUEST   => 'DELETE',
+      CURLOPT_TIMEOUT => $this->timeout
+    );
+    $curl = curl_init();
+    curl_setopt_array($curl, $defaults );
+    $result = $this->send($curl,'deleted');
+    curl_close($curl);
+    return $result;
+  }
+
+  // Execute the curl command
+  // 2nd parameter `$desired` indicates the value expected to be returned.
+  // This is used in PUT an DELETE calls when a 204 is the status, so we can differentiate between the two returns.
+  private function send($curl, $desired = false) {
+    $this->logger->debug("send()");
+    $return = false;
+    $this->logger->debug(sprintf("send():\n\tuoid = %s\n\tpoid = %s",$this->uoid,$this->poid));
+    // Authentication header!!
+    curl_setopt($curl, CURLOPT_USERPWD, "{$this->uoid}:{$this->poid}");
+
+    $result = curl_exec($curl);
+    $url = curl_getinfo($curl,CURLINFO_EFFECTIVE_URL);
+    $status = (int)curl_getinfo($curl, CURLINFO_HTTP_CODE);
+    $this->logger->debug(sprintf("send():\n\tURL = %s\n\tStatus = %s",$url,$status));
+    // Check for errors
+    if ( curl_errno($curl) ) {
+      $this->error = sprintf('HeyPublisher API Error : %s', curl_error($curl));
+    }
+    else {
+      switch($status){
+        case 200:   // success GET
+          $return = json_decode($result, true);
+          break;
+        case 201:   // success POST
+          $return = json_decode($result, true);
+          break;
+        case 204:   // success for PUT & DELETE
+          $return = $desired;
+          break;
+        default:
+          if ($result) {
+            $data = json_decode($result, true);
+            $message = $data['message'];
+            $this->logger->debug(sprintf("\tdata = %s",print_r($data,1)));
+            $this->error = sprintf('HeyPublisher API Error : %s (%s)', $message, $status);
+          } else {
+            $this->error = sprintf('HeyPublisher API Return Status : %s', $status);
+          }
+          $this->logger->debug(sprintf("\treturning error %s",$this->error));
+          break;
+      }
+    }
+    $this->logger->debug("\treturning from send: {$status}");
+    return $return;
+  }
+
+  public function authentication_token() {
+    $pass = "{$this->uoid}:{$this->poid}";
+    $token = base64_encode($pass);
+    return $token;
+  }
+
+  private function clean_post_vars($array) {
+    $tmp = array();
+    foreach ($array as $key=>$val) {
+      if (is_scalar($val)) {
+        $tmp[$key] = htmlentities(stripslashes($val));
+      } else {
+        $tmp[$key] = $val;
+      }
+    }
+    return $tmp;
+  }
+
+  protected function get_from_cache($key) {
+    $this->logger->debug("\tget_from_cache '{$key}' from cache");
+    $hash = $this->config->get_config_option($key);
+    $expry = date('U');
+    if ($hash && ($hash['cache_date'] + 86400) > $expry) { // 1 day cache only
+      unset($hash['cache_date']);
+      $this->logger->debug(sprintf("\tcache is FRESH\n\tcache = %s",print_r($hash,1)));
+      return $hash;
+    }
+    // $this->logger->debug(sprintf("\tcache date = %s\n\texpiry = %s\n\tdiff = %s",$hash['cache_date'],$expry,($hash['cache_date']- $expry)));
+    $this->logger->debug("\tcache is OLD '{$key}'");
+    return;
+  }
+
+  protected function set_to_cache($key,$hash) {
+    $this->logger->debug(sprintf("\tset_to_cache '%s' to cache %s",$key,print_r($hash,1)));
+    $hash['cache_date'] = date('U');
+    $hash = $this->config->set_config_option($key,$hash);
+  }
+}
+?>

--- a/include/classes/HeyPublisher/Base.class.php
+++ b/include/classes/HeyPublisher/Base.class.php
@@ -12,7 +12,6 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('HeyP
 *
 */
 class Base {
-  var $debug = true;
   var $logger = null;
   var $help = false;
   var $i18n = 'heypublisher';  // key for internationalization stubs

--- a/include/classes/HeyPublisher/Base.class.php
+++ b/include/classes/HeyPublisher/Base.class.php
@@ -2,7 +2,7 @@
 namespace HeyPublisher;
 
 if (!class_exists("\HeyPublisher\Base\Log")) {
-  require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/Log.class.php');
+  require_once( dirname(__FILE__) . '/Base/Log.class.php');
 }
 
 if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('HeyPublisher: Illegal Page Call!'); }

--- a/include/classes/HeyPublisher/Base/API.class.php
+++ b/include/classes/HeyPublisher/Base/API.class.php
@@ -15,7 +15,7 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('HeyP
 class API {
   var $api   = null;
   var $error  = false;
-  var $timeout = 4;
+  var $timeout = 3;
   var $config = null;
   var $uoid   = null;
   var $poid   = null;

--- a/include/classes/HeyPublisher/Base/API.class.php
+++ b/include/classes/HeyPublisher/Base/API.class.php
@@ -13,12 +13,12 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('HeyP
   // via the global $HEYPUB_LOGGER
 
 class API {
-  var $api = HEYPUB_API;
-  var $error = false;
+  var $api   = null;
+  var $error  = false;
   var $timeout = 4;
   var $config = null;
-  var $uoid = '';
-  var $poid = '';
+  var $uoid   = null;
+  var $poid   = null;
 
   public function __construct() {
     // TODO: to make this generic, the uoid and poid need to be dynamic
@@ -26,7 +26,7 @@ class API {
     global $HEYPUB_LOGGER;
     $this->logger = $HEYPUB_LOGGER;
     $this->logger->debug("HeyPublisher::API loaded");
-    // Load the uoid and poid into memory
+    $this->initialize_api_url();
     $this->initialize_oids();
     register_shutdown_function(array($this,'shutdown'));
   }
@@ -211,6 +211,18 @@ class API {
     }
     return $tmp;
   }
+  // Set the API URL depending on whether we're in dev or prod
+  private function initialize_api_url() {
+    $domain = 'https://www.heypublisher.com';
+    $debug = (getenv('HEYPUB_DEBUG') === 'true');
+    if ($debug) {
+      $domain = 'http://127.0.0.1:3000';
+    }
+    $this->api = sprintf("%s/api",$domain);
+    $this->logger->debug(sprintf("\tAPI URL: %s",$this->api));
+  }
+
+  // Load the uoid and poid into memory
   private function initialize_oids() {
     global $hp_config;
     $this->logger->debug("API#initialize_oids()");

--- a/include/classes/HeyPublisher/Base/API.class.php
+++ b/include/classes/HeyPublisher/Base/API.class.php
@@ -26,6 +26,7 @@ class API {
     global $HEYPUB_LOGGER;
     $this->logger = $HEYPUB_LOGGER;
     $this->logger->debug("HeyPublisher::API loaded");
+
     $this->initialize_api_url();
     $this->initialize_oids();
     register_shutdown_function(array($this,'shutdown'));

--- a/include/classes/SGW_Widget.class.php
+++ b/include/classes/SGW_Widget.class.php
@@ -7,6 +7,7 @@ class SupportGreatWriters extends WP_Widget {
   var $seen = array();
   var $options = array();
   var $asins = array();
+  var $asin_meta = array();
   var $logger = null;
 
 	function __construct() {
@@ -37,15 +38,23 @@ class SupportGreatWriters extends WP_Widget {
       // display default image
       $link = sprintf('<img src="%s" title="Product ASIN not defined">',SGW_DEFAULT_IMAGE);
     } else {
-      $format = '<a title="Click for more Information" target=_blank href="https://www.%s/gp/product/%s?ie=UTF8&tag=%s&linkCode=as2&camp=1789&creative=9325&creativeASIN=%s"><img class="sgw_product_img" src="http://ecx.images-amazon.com/images/P/%s.01._SCMZZZZZZZ_.jpg"></a><img src="https://www.assoc-%s/e/ir?t=%s&l=as2&o=1&a=%s" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" />';
-      $link = sprintf($format,$url_map[$country],$asin,$assoc,$asin,$asin,$url_map[$country],$assoc,$asin);
+      if (isset($this->asin_meta[$asin]['image'])) {
+        $image = $this->asin_meta[$asin]['image']; // secure URL image
+        $title = $this->asin_meta[$asin]['title'];
+      } else {
+        $image = sprintf("http://ecx.images-amazon.com/images/P/%s.01._SCMZZZZZZZ_.jpg",$asin); // secure URL image
+        $title = "Click for more Information";
+      }
+
+      $format = '<a title="%s" target=_blank href="https://www.%s/gp/product/%s?ie=UTF8&tag=%s&linkCode=as2&camp=1789&creative=9325&creativeASIN=%s"><img class="sgw_product_img" src="%s"></a><img src="https://www.assoc-%s/e/ir?t=%s&l=as2&o=1&a=%s" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" />';
+      $link = sprintf($format,$title,$url_map[$country],$asin,$assoc,$asin,$image,$url_map[$country],$assoc,$asin);
     }
     return $link;
   }
 
   // Split a comma-separated list of asins apart and return an array of POST or DEFAULT asins for display.
   private function shuffle_asin_list($list) {
-    $this->logger->debug(sprintf("\tshuffle_asin_list : \n\t\$list = %s",print_r($list,1)));
+    $this->logger->debug(sprintf("SupportGreatWriters#shuffle_asin_list()\n\t\$list = %s",print_r($list,1)));
     $asins = array();
     if ($list) {
   	  $array = explode(',',$list);
@@ -58,13 +67,28 @@ class SupportGreatWriters extends WP_Widget {
   public function load_asins() {
 	  global $post; // this is only available within the widget function, not within the constructor
     $list = '';
+    $hash = array();
     if (!is_home()) {
       // look to see if we have a post id meta attribute
   	  $list = get_post_meta($post->ID,SGW_POST_META_KEY,true);
+      $hash = get_post_meta($post->ID,SGW_POST_ASINDATA_KEY,false);
   	  $this->asins = array_merge($this->asins,$this->shuffle_asin_list($list));
+      // $hash may not be populated or may not be an array
+      if (is_array($hash)) {
+        $this->asin_meta = $this->asin_meta = $hash;
+        // $this->asin_meta = array_merge($this->asin_meta,$hash);
+      }
+      $this->logger->debug(sprintf("SupportGreatWriters#load_asins()\n\t\$asin_meta = %s",print_r($this->asin_meta,1)));
     }
     // concatenate the defaults onto the end
     $this->asins = array_merge($this->asins,$this->shuffle_asin_list($this->options['default']));
+    // include the default hash of asin meta data
+    // it may be that we don't have the default meta data - so test for that scenario
+    $meta = $this->options['default_meta'];
+    if (is_array($meta)) {
+      $this->asin_meta = $this->asin_meta + $meta;
+      // $this->asin_meta = array_merge($this->asin_meta,$meta);
+    }
     // need to uniquify the array to prevent duplicates
     $this->asins = array_unique($this->asins);
   }

--- a/include/classes/SGW_Widget.class.php
+++ b/include/classes/SGW_Widget.class.php
@@ -31,7 +31,8 @@ class SupportGreatWriters extends WP_Widget {
       'fr'      => 'amazon.fr',
       'ca'      => 'amazon.ca',
       'it'      => 'amazon.it',
-      'es'      => 'amazon.es'
+      'es'      => 'amazon.es',
+      'br'      => 'amazon.com.br'
     );
 
     if (!$asin) {

--- a/include/classes/SGW_Widget.class.php
+++ b/include/classes/SGW_Widget.class.php
@@ -72,10 +72,17 @@ class SupportGreatWriters extends WP_Widget {
       // look to see if we have a post id meta attribute
   	  $list = get_post_meta($post->ID,SGW_POST_META_KEY,true);
       $hash = get_post_meta($post->ID,SGW_POST_ASINDATA_KEY,false);
+
+      // TODO: Need to test the hash against the list and if not the same keys,
+      // need to update the hash against API
+
+
+
+
   	  $this->asins = array_merge($this->asins,$this->shuffle_asin_list($list));
       // $hash may not be populated or may not be an array
       if (is_array($hash)) {
-        $this->asin_meta = $this->asin_meta = $hash;
+        $this->asin_meta = $this->asin_meta + $hash;
         // $this->asin_meta = array_merge($this->asin_meta,$hash);
       }
       $this->logger->debug(sprintf("SupportGreatWriters#load_asins()\n\t\$asin_meta = %s",print_r($this->asin_meta,1)));

--- a/include/classes/SGW_Widget.class.php
+++ b/include/classes/SGW_Widget.class.php
@@ -50,13 +50,8 @@ class SupportGreatWriters extends WP_Widget {
       // Need to updtae to use this page URL
       $pageUrl = sprintf("https://www.%s/dp/%s?tag=%s&linkCode=ogi&th=1&psc=1",$url_map[$country],$asin,$assoc);
 
-      // Associates Central says this should be the link
-      // <a target="_blank"  href="https://www.amazon.com/gp/product/2070319857/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=2070319857&linkCode=as2&tag=pifaliterajourna&linkId=e921fb006cada4fc24bde63e4deff734"><img border="0" src="//ws-na.amazon-adsystem.com/widgets/q?_encoding=UTF8&MarketPlace=US&ASIN=2070319857&ServiceVersion=20070822&ID=AsinImage&WS=1&Format=_SL250_&tag=pifaliterajourna" ></a><img src="//ir-na.amazon-adsystem.com/e/ir?t=pifaliterajourna&l=am2&o=1&a=2070319857" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" />
-
-      // Link checking does not require all of the tracking pixels though.
-
-      $format = '<a title="%s" target="_blank" href="%s"><img class="sgw_product_img" src="%s"></a><img src="https://www.assoc-%s/e/ir?t=%s&l=as2&o=1&a=%s" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" />';
-      $link = sprintf($format,$title,$pageUrl,$image,$url_map[$country],$assoc,$asin);
+      $format = '<a title="%s" target="_blank" href="%s"><img class="sgw_product_img" src="%s"></a>';
+      $link = sprintf($format,$title,$pageUrl,$image);
     }
     return $link;
   }

--- a/include/js/sgw.js
+++ b/include/js/sgw.js
@@ -8,13 +8,14 @@
   var WIDGET_CNT = 0;
   var WIDGET_SET = {};
   var AFFILIATES = {
-    'com':    {domain: 'https://affiliate-program.amazon.com', id: 'sgw02-20  '},
+    'com':    {domain: 'https://affiliate-program.amazon.com', id: 'pif-richard-20'},
     'co.uk':  {domain: 'https://affiliate-program.amazon.co.uk', id: 'sgw0a-21'},
     'de':     {domain: 'https://partnernet.amazon.de', id: 'sgw05-21'},
     'fr':     {domain: 'https://partenaires.amazon.fr', id: 'sgw08-21'},
     'it':     {domain: 'https://programma-affiliazione.amazon.it', id: 'sgw0c-21'},
     'es':     {domain: 'https://afiliados.amazon.es', id: 'sgw0f-21'},
-    'ca':     {domain: 'https://associates.amazon.ca', id: 'sgw0a-20'}
+    'ca':     {domain: 'https://associates.amazon.ca', id: 'sgw0a-20'},
+    'br':     {domain: 'https://associados.amazon.com.br/', id: 'sgw0b-20'}
   };
 
   function getAffiliateId(region) {

--- a/support_great_writers.php
+++ b/support_great_writers.php
@@ -74,8 +74,8 @@ define('SGW_PLUGIN_FULLPATH', dirname(__FILE__));
 if (!class_exists("\HeyPublisher\Base\Log")) {
   require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/Log.class.php');
 }
-if (!class_exists("\HeyPublisher\Base\API")) {
-  require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/API.class.php');
+if (!class_exists("\AMZNBS\ASIN")) {
+  require_once(SGW_PLUGIN_FULLPATH . '/include/classes/AMZNBS/ASIN.class.php');
 }
 if (!class_exists("\HeyPublisher\Base\Updater")) {
   require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/Updater.class.php');
@@ -85,9 +85,10 @@ $sgw_updater = new \HeyPublisher\Base\Updater( __FILE__ );
 $sgw_updater->set_repository( 'amazon-book-store' ); // set repo
 $sgw_updater->initialize(SGW_PLUGIN_TESTED); // initialize the updater
 
-require_once(dirname(__FILE__) . '/include/classes/SGW_Widget.class.php');
-require_once(dirname( __FILE__ ) . '/include/classes/AMZNBS/Admin.class.php');
+require_once(SGW_PLUGIN_FULLPATH . '/include/classes/SGW_Widget.class.php');
+require_once(SGW_PLUGIN_FULLPATH . '/include/classes/AMZNBS/Admin.class.php');
 $sgw = new \AMZNBS\Admin;
+
 
 // enable link to settings page
 add_filter($sgw->plugin_filter(), array(&$sgw,'plugin_link'), 10, 2 );

--- a/support_great_writers.php
+++ b/support_great_writers.php
@@ -87,19 +87,19 @@ $sgw_updater->initialize(SGW_PLUGIN_TESTED); // initialize the updater
 
 require_once(SGW_PLUGIN_FULLPATH . '/include/classes/SGW_Widget.class.php');
 require_once(SGW_PLUGIN_FULLPATH . '/include/classes/AMZNBS/Admin.class.php');
-$sgw = new \AMZNBS\Admin;
+$SGW_ADMIN = new \AMZNBS\Admin;
 
 
 // enable link to settings page
-add_filter($sgw->plugin_filter(), array(&$sgw,'plugin_link'), 10, 2 );
+add_filter($SGW_ADMIN->plugin_filter(), array(&$SGW_ADMIN,'plugin_link'), 10, 2 );
 
 function RegisterAdminPage() {
-  global $sgw;
+  global $SGW_ADMIN;
   // ensure our js and style sheet only get loaded on our admin page
-  $page = add_options_page('Amazon Book Store', 'Amazon Book Store', 'manage_options', SGW_ADMIN_PAGE, array(&$sgw,'action_handler'));
-  $sgw->help = $page;
+  $page = add_options_page('Amazon Book Store', 'Amazon Book Store', 'manage_options', SGW_ADMIN_PAGE, array(&$SGW_ADMIN,'action_handler'));
+  $SGW_ADMIN->help = $page;
   add_action("admin_print_scripts-$page", 'AdminInit');
-  add_action("admin_print_styles-$page", array(&$sgw,'admin_stylesheets'));
+  add_action("admin_print_styles-$page", array(&$SGW_ADMIN,'admin_stylesheets'));
 }
 
 function AdminInit() {
@@ -113,9 +113,9 @@ if (class_exists("SupportGreatWriters")) {
   add_action('widgets_init', create_function('', 'return register_widget("SupportGreatWriters");'));
   add_action('admin_menu', 'RegisterAdminPage');
 	add_action('wp_enqueue_scripts','RegisterWidgetStyle');
-	add_filter('contextual_help', array(&$sgw,'configuration_screen_help'), 10, 3);
+	add_filter('contextual_help', array(&$SGW_ADMIN,'configuration_screen_help'), 10, 3);
 
 }
-register_activation_hook( __FILE__, array(&$sgw,'activate_plugin'));
-register_deactivation_hook( __FILE__, array(&$sgw,'deactivate_plugin'));
+register_activation_hook( __FILE__, array(&$SGW_ADMIN,'activate_plugin'));
+register_deactivation_hook( __FILE__, array(&$SGW_ADMIN,'deactivate_plugin'));
 ?>

--- a/support_great_writers.php
+++ b/support_great_writers.php
@@ -103,10 +103,10 @@ function RegisterAdminPage() {
 }
 
 function AdminInit() {
-  wp_enqueue_script('sgw', WP_PLUGIN_URL . '/support-great-writers/include/js/sgw.js');
+  wp_enqueue_script('sgw', WP_PLUGIN_URL . '/support-great-writers/include/js/sgw.js',array(),SGW_PLUGIN_VERSION);
 }
 function RegisterWidgetStyle() {
-	wp_enqueue_style( 'sgw_widget', SGW_BASE_URL . 'css/sgw_widget.css', array(), '1.2.2' );
+	wp_enqueue_style( 'sgw_widget', SGW_BASE_URL . 'css/sgw_widget.css', array(), SGW_PLUGIN_VERSION );
 }
 
 if (class_exists("SupportGreatWriters")) {

--- a/support_great_writers.php
+++ b/support_great_writers.php
@@ -75,6 +75,9 @@ define('SGW_PLUGIN_FULLPATH', dirname(__FILE__));
 if (!class_exists("\HeyPublisher\Base\Log")) {
   require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/Log.class.php');
 }
+if (!class_exists("\HeyPublisher\Base\API")) {
+  require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/API.class.php');
+}
 if (!class_exists("\HeyPublisher\Base\Updater")) {
   require_once(SGW_PLUGIN_FULLPATH . '/include/classes/HeyPublisher/Base/Updater.class.php');
 }

--- a/support_great_writers.php
+++ b/support_great_writers.php
@@ -63,12 +63,11 @@ define('SGW_PLUGIN_TESTED', '5.3.0');
 define('SGW_PLUGIN_OPTTIONS', '_sgw_plugin_options');
 define('SGW_BASE_URL', get_option('siteurl').'/wp-content/plugins/support-great-writers/');
 define('SGW_DEFAULT_IMAGE', get_option('siteurl').'/wp-content/plugins/support-great-writers/images/not_found.gif');
-define('SGW_POST_META_KEY','SGW_ASIN');
+define('SGW_POST_META_KEY','SGW_ASIN');           // This is the visible meta data key
+define('SGW_POST_ASINDATA_KEY','_sgw_asindata');  // This is the invisible one that is structured hash
 define('SGW_ADMIN_PAGE','amazon_bookstore');
 define('SGW_ADMIN_PAGE_NONCE','sgw-save-options');
 define('SGW_PLUGIN_ERROR_CONTACT','Please contact <a href="mailto:wordpress@heypublisher.com?subject=Amazon%20Bookstore%20Widget">wordpress@heypublisher.com</a> if you have any questions');
-// Modify the defaults to show
-define('SGW_BESTSELLERS','1455570249,144947425X,1501164589,0692859055');
 define('SGW_PLUGIN_FILE',plugin_basename(__FILE__));
 define('SGW_PLUGIN_FULLPATH', dirname(__FILE__));
 


### PR DESCRIPTION
Lots of effeciency changes.

To begin with, to work around the issue of non-secure image urls being displayed by the previous version of the plugin, this version will attempt to fetch secure URL images directly from Amazon's PAAPI.  Since that requires authorization and an API Key/Secret combo, which most users of this plugin do not have, the plugin leverages HeyPublisher's key/secret.

When a new ASIN is detected that is not cached locally in WP, the plugin will call out out to HeyPublisher API.  If found cached at HeyPublisher, it is returned.  If not, HeyPublisher will fetch the asin image from PAAPI and return it.